### PR TITLE
Added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask_cors
+flask
+flask_restful


### PR DESCRIPTION
Adding a requirements.txt to make life easier for future contributors.

Packages can be installed with `pip install -r requirements.txt`